### PR TITLE
Fixes Issue #3

### DIFF
--- a/tasks/smartsprites.js
+++ b/tasks/smartsprites.js
@@ -43,7 +43,8 @@ module.exports = function(grunt) {
             var camelized = _s.camelize(opt);
 
             if (data[camelized]) {
-                args.push('--' + opt + ' ' + data[camelized] + '');
+                args.push('--' + opt);
+                args.push(data[camelized]);
             }
         });
 


### PR DESCRIPTION
Fixes Issue #3 : Prevent `"--root-dir-path ..." is not a valid option` errors under windows 7

There still are 2 failing tests, yet none were passing before because smartsprites would not run at all.
